### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,7 @@
     "type": "git",
     "url": "git://github.com/SassDoc/sass-convert.git"
   },
-  "license": {
-    "type": "unlicence",
-    "url": "http://unlicense.org"
-  },
+  "license": "Unlicence",
   "files": [
     "bin",
     "dist",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license